### PR TITLE
Minor fix in indices

### DIFF
--- a/lectures/lecture15/lecture-15.ipynb
+++ b/lectures/lecture15/lecture-15.ipynb
@@ -350,7 +350,7 @@
     "Using the known values on the diagonal and the commutativity property, we get the diagonals of the matrix one-by-one:\n",
     "\n",
     "\n",
-    "$$f_{ij} = t_{ij} \\frac{f_{ii} - f_{jj}}{t_{ii} - t_{jj}} + \\sum_{k=i+1}^{j-1} \\frac{f_{ik} t_{kj} - t_{ki}f_{kj}}{t_{ii} - t_{jj}}.$$"
+    "$$f_{ij} = t_{ij} \\frac{f_{ii} - f_{jj}}{t_{ii} - t_{jj}} + \\sum_{k=i+1}^{j-1} \\frac{f_{ik} t_{kj} - t_{ik}f_{kj}}{t_{ii} - t_{jj}}.$$"
    ]
   },
   {
@@ -1181,7 +1181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.4"
   },
   "nav_menu": {},
   "toc": {


### PR DESCRIPTION
In last equation from _Computing functions of triangular matrices_ there are a mistake in indices. It can be checked in simple example with 3x3 matrices. Also you can find prove in Algorithm 1 of this [article](https://arxiv.org/pdf/1607.06303v1.pdf).